### PR TITLE
Add serializers for API resources

### DIFF
--- a/park-app-backend/Gemfile
+++ b/park-app-backend/Gemfile
@@ -16,6 +16,9 @@ gem 'puma', '~> 3.11'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# Serialization for API data standardization
+gem 'active_model_serializers', '~> 0.10.0'
+
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'
 

--- a/park-app-backend/Gemfile.lock
+++ b/park-app-backend/Gemfile.lock
@@ -24,6 +24,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (5.2.4.3)
       activesupport (= 5.2.4.3)
       globalid (>= 0.3.6)
@@ -47,6 +52,8 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
+    case_transform (0.2)
+      activesupport
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     erubi (1.9.0)
@@ -55,6 +62,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
+    jsonapi-renderer (0.2.2)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -134,6 +142,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers (~> 0.10.0)
   bootsnap (>= 1.1.0)
   byebug
   listen (>= 3.0.5, < 3.2)

--- a/park-app-backend/app/controllers/parks_controller.rb
+++ b/park-app-backend/app/controllers/parks_controller.rb
@@ -1,17 +1,12 @@
 class ParksController < ApplicationController
     def index
         parks = Park.all
-        render json: parks, except: excluded_data
+        render json: parks
     end
 
     def show
         park = Park.find([params[:id]])
-        render json: park, except: excluded_data
+        render json: park
     end
 
-    private
-
-    def excluded_data
-        [:created_at, :updated_at]
-    end
 end

--- a/park-app-backend/app/controllers/states_controller.rb
+++ b/park-app-backend/app/controllers/states_controller.rb
@@ -1,12 +1,12 @@
 class StatesController < ApplicationController
     def index
         states = State.all
-        render json: states, include: [:parks => {except: excluded_data}], except: excluded_data
+        render json: states
     end
     
     def show
         state = State.find(params[:id])
-        render json: state, include: [:parks => {except: excluded_data}], except: excluded_data
+        render json: state
     end
 
     def create
@@ -25,7 +25,4 @@ class StatesController < ApplicationController
         params.permit(:name)
     end
 
-    def excluded_data
-        [:created_at, :updated_at]
-    end
 end

--- a/park-app-backend/app/serializers/park_serializer.rb
+++ b/park-app-backend/app/serializers/park_serializer.rb
@@ -1,0 +1,3 @@
+class ParkSerializer < ActiveModel::Serializer
+  attributes :id, :name, :state_id
+end

--- a/park-app-backend/app/serializers/state_serializer.rb
+++ b/park-app-backend/app/serializers/state_serializer.rb
@@ -1,0 +1,5 @@
+class StateSerializer < ActiveModel::Serializer
+  attributes :id, :name
+
+  has_many :parks, serializer: ParkSerializer
+end


### PR DESCRIPTION
On master, the current ways the API renders resources violates the DRY (don't repeat yourself) principle. Here's a code snippet from the ParksController controller:

```ruby
class ParksController < ApplicationController
    def index
        parks = Park.all
        render json: parks, except: excluded_data
    end

    def show
        park = Park.find([params[:id]])
        render json: park, except: excluded_data
    end

    private

    def excluded_data
        [:created_at, :updated_at]
    end
end
```

This is the simplest controller class, but in it similar code is repeated twice. The way parks are rendered is that **all** the data that is stored in our database is being pulled, including extraneous data such as `created_at` and `updated_at` which we don't currently use with our frontend. In order to not include this data in the rendered JSON, we need to add `except: [:created_at, :updated_at]` to each JSON render, which was simplified in the code to `except: excluded_data`, where the method `excluded_data` returns `[:created_at, :updated_at]`.

While this solution certainly works for smaller resources with little data, it doesn't scale well with larger resources when more data is required to be filtered. Plus, this implementation violates the separation of concerns principle: controllers should only be concerned with what to render and how to render it, not the filtering of what it's rendering. It would be much more efficient and organized to use a serializer instead, which filters all of the details in it's own class.

Implementing the serializers is simple. As an example, here's the implementation of the new ParkSerializer:

```ruby
# park_serializer.rb
class ParkSerializer < ActiveModel::Serializer
  attributes :id, :name, :state_id
end
```

Using the `attributes` macro, we can easily decide what data will be presented whenever the data for any `Park` is rendered. 

With the new serializer implementation, our controllers become much simpler and easier to manage:

```ruby
# parks_controller.rb
class ParksController < ApplicationController
    def index
        parks = Park.all
        render json: parks
    end

    def show
        park = Park.find([params[:id]])
        render json: park
    end

end
```

We can entirely remove the `except` from the end of each render, along with our method which returns the data we don't want to be rendered. 

I've already implemented the serializer with the other resource in this project, `States`, and removed the verbose `excepts` from the renders of the resource in the controller. 